### PR TITLE
fix: android capture preview permissions add RECORD_AUDIO

### DIFF
--- a/android/src/main/java/com/ahm/capacitor/camera/preview/CameraPreview.java
+++ b/android/src/main/java/com/ahm/capacitor/camera/preview/CameraPreview.java
@@ -1,6 +1,7 @@
 package com.ahm.capacitor.camera.preview;
 
 import static android.Manifest.permission.CAMERA;
+import static android.Manifest.permission.RECORD_AUDIO;
 
 import android.app.FragmentManager;
 import android.app.FragmentTransaction;
@@ -28,7 +29,7 @@ import java.io.File;
 import java.util.List;
 import org.json.JSONArray;
 
-@CapacitorPlugin(name = "CameraPreview", permissions = { @Permission(strings = { CAMERA }, alias = CameraPreview.CAMERA_PERMISSION_ALIAS) })
+@CapacitorPlugin(name = "CameraPreview", permissions = { @Permission(strings = { CAMERA, RECORD_AUDIO }, alias = CameraPreview.CAMERA_PERMISSION_ALIAS) })
 public class CameraPreview extends Plugin implements CameraActivity.CameraPreviewListener {
 
     static final String CAMERA_PERMISSION_ALIAS = "camera";


### PR DESCRIPTION
This PR adds the request to use the RECORD_AUDIO permission to the android capture preview, preventing the intent from erroring due to insufficient perms.